### PR TITLE
Main  preview fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { Footer } from '@/components/Footer';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import { type Bookmark, type BookmarkTemplate } from '@/lib/bookmarks';
 import { Toaster } from '@/components/ui/sonner';
-import { FileText, Gear, Eye } from '@phosphor-icons/react';
+import { FileTextIcon, GearIcon, EyeIcon } from '@phosphor-icons/react';
 
 function App() {
   const [selectedTemplate, setSelectedTemplate] = useState<BookmarkTemplate | null>(null);
@@ -30,7 +30,7 @@ function App() {
                 <div className="flex-1" />
                 <div className="flex items-center justify-center gap-3">
                   <div className="w-12 h-12 bg-primary rounded-lg flex items-center justify-center shadow-lg hidden sm:flex">
-                    <FileText size={24} className="text-primary-foreground" />
+                    <FileTextIcon size={24} className="text-primary-foreground" />
                   </div>
                   <h1 className="text-4xl font-light text-foreground">
                     Microsoft 365 Bookmarks Generator
@@ -55,7 +55,7 @@ function App() {
               <CardHeader className="pb-4">
                 <CardTitle className="flex items-center gap-3 text-xl font-medium">
                   <div className="w-8 h-8 bg-primary/10 rounded-md flex items-center justify-center">
-                    <FileText size={18} className="text-primary" />
+                    <FileTextIcon size={18} className="text-primary" />
                   </div>
                   Quick Start Guide
                 </CardTitle>
@@ -102,15 +102,15 @@ function App() {
             <Tabs defaultValue="templates" className="space-y-8">
               <TabsList className="w-full max-w-md mx-auto grid grid-cols-3 bg-fluent-neutral-10 border border-border">
                 <TabsTrigger value="templates" className="flex items-center gap-2 data-[state=active]:bg-card data-[state=active]:shadow-sm">
-                  <FileText size={16} />
+                  <FileTextIcon size={16} />
                   Templates
                 </TabsTrigger>
                 <TabsTrigger value="manage" className="flex items-center gap-2 data-[state=active]:bg-card data-[state=active]:shadow-sm">
-                  <Gear size={16} />
+                  <GearIcon size={16} />
                   Manage
                 </TabsTrigger>
                 <TabsTrigger value="preview" className="flex items-center gap-2 data-[state=active]:bg-card data-[state=active]:shadow-sm">
-                  <Eye size={16} />
+                  <EyeIcon size={16} />
                   Preview
                 </TabsTrigger>
               </TabsList>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ function App() {
               <div className="flex items-center justify-between mb-6">
                 <div className="flex-1" />
                 <div className="flex items-center justify-center gap-3">
-                  <div className="w-12 h-12 bg-primary rounded-lg flex items-center justify-center shadow-lg">
+                  <div className="w-12 h-12 bg-primary rounded-lg flex items-center justify-center shadow-lg hidden sm:flex">
                     <FileText size={24} className="text-primary-foreground" />
                   </div>
                   <h1 className="text-4xl font-light text-foreground">

--- a/src/components/BookmarkManager.tsx
+++ b/src/components/BookmarkManager.tsx
@@ -213,7 +213,7 @@ export function BookmarkManager({ bookmarks, onBookmarksChange }: BookmarkManage
                   <FolderOpenIcon size={18} className="text-accent" />
                 </div>
                 <span>{folder}</span>
-                <div className="px-2 py-1 bg-fluent-neutral-20 rounded-full">
+                <div className="w-7 h-7 flex items-center justify-center bg-fluent-neutral-20 rounded-full">
                   <span className="text-xs font-medium text-muted-foreground">
                     {folderBookmarks.length}
                   </span>

--- a/src/components/BookmarkPreview.tsx
+++ b/src/components/BookmarkPreview.tsx
@@ -122,7 +122,7 @@ export function BookmarkPreview({ bookmarks, groupName }: BookmarkPreviewProps) 
             </CardContent>
           </Card>
 
-          <div className="bg-gradient-to-br from-primary/5 via-primary/3 to-accent/5 border border-primary/20 rounded-xl p-8 shadow-sm">
+          <div className="bg-gradient-to-br from-primary/5 via-primary/3 to-accent/5 border border-primary/20 rounded-xl p-8 shadow-sm min-w-0">
             <div className="flex items-center gap-4 mb-6">
               <div className="w-12 h-12 bg-primary/10 rounded-xl flex items-center justify-center shadow-sm">
                 <GlobeIcon size={24} className="text-primary" />
@@ -153,8 +153,8 @@ export function BookmarkPreview({ bookmarks, groupName }: BookmarkPreviewProps) 
                     {folderBookmarks.map((bookmark) => (
                       <div key={bookmark.id} className="flex items-center gap-3 text-sm p-2 bg-card/50 rounded-lg border border-border/30">
                         <div className="w-1.5 h-1.5 bg-primary rounded-full flex-shrink-0" />
-                        <span className="text-foreground font-medium">{bookmark.name}</span>
-                        <span className="text-muted-foreground text-xs truncate font-mono bg-fluent-neutral-20 px-2 py-1 rounded flex-1">
+                        <span className="text-foreground truncate font-medium">{bookmark.name}</span>
+                        <span className="text-muted-foreground text-xs font-mono bg-fluent-neutral-20 px-2 py-1 rounded flex-1 break-all truncate">
                           {bookmark.url}
                         </span>
                       </div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/components/ui/button';
-import { Moon, Sun } from '@phosphor-icons/react';
+import { MoonIcon, SunIcon } from '@phosphor-icons/react';
 import { useTheme } from '@/contexts/ThemeContext';
 
 export function ThemeToggle() {
@@ -13,9 +13,9 @@ export function ThemeToggle() {
       className="w-9 h-9 p-0"
     >
       {theme === 'light' ? (
-        <Moon size={16} />
+        <MoonIcon size={16} />
       ) : (
-        <Sun size={16} />
+        <SunIcon size={16} />
       )}
       <span className="sr-only">
         Switch to {theme === 'light' ? 'dark' : 'light'} mode


### PR DESCRIPTION
Fixes #11 

This pull request primarily updates icon imports throughout the codebase to use the new `*Icon` naming convention from the `@phosphor-icons/react` library. Additionally, there are several small UI improvements for consistency and layout.

**Icon Import and Usage Updates:**

* Replaced all instances of `FileText`, `Gear`, `Eye`, `Moon`, and `Sun` with their new counterparts (`FileTextIcon`, `GearIcon`, `EyeIcon`, `MoonIcon`, `SunIcon`) in both `src/App.tsx` and `src/components/ThemeToggle.tsx` to match the updated `@phosphor-icons/react` exports. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L12-R12) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L32-R33) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L58-R58) [[4]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L105-R113) [[5]](diffhunk://#diff-5cd95420755f79ed0fcea438247ffa21c249ddb1d277ec2d9333798bc18edbd0L2-R2) [[6]](diffhunk://#diff-5cd95420755f79ed0fcea438247ffa21c249ddb1d277ec2d9333798bc18edbd0L16-R18)

**UI and Layout Improvements:**

* Adjusted the folder badge container in `BookmarkManager` to have fixed width and height for better alignment.
* Added `min-w-0` to the preview card container in `BookmarkPreview` to improve layout flexibility.
* Improved text truncation and line breaking for bookmark URLs in `BookmarkPreview` to prevent overflow and enhance readability.